### PR TITLE
Fix build command in README and disable proportional icon in PDF signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ junto com este programa. Se não, veja <https://www.gnu.org/licenses/>.
 
 ## Building
 
-Run `mvn deploy` to create the JAR file in the `target` folder.
+Run `mvn package` to create the JAR file in the `target` folder.
 
 ## Running
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ junto com este programa. Se não, veja <https://www.gnu.org/licenses/>.
 
 ## Building
 
-Run `mvn pakage` to create the JAR file in the `target` folder.
+Run `mvn deploy` to create the JAR file in the `target` folder.
 
 ## Running
 

--- a/src/main/java/com/vaultid/engine/PreparePdfToSignLogic.java
+++ b/src/main/java/com/vaultid/engine/PreparePdfToSignLogic.java
@@ -289,7 +289,7 @@ public class PreparePdfToSignLogic implements Runnable {
                     } else if (((String) field.get("type")).equals("image")) {
                         PushbuttonField ad = acroFields.getNewPushbuttonFromField((String) field.get("name"));
                         ad.setLayout(PushbuttonField.LAYOUT_ICON_ONLY);
-                        ad.setProportionalIcon(true);
+                        ad.setProportionalIcon(false);
                         ad.setImage(Image.getInstance((String) field.get("value")));
                         acroFields.replacePushbuttonField((String) field.get("name"), ad.getField());
                     }


### PR DESCRIPTION
This pull request includes minor updates to the documentation and a small adjustment to the PDF signing logic. The most important changes are:

Documentation update:

* Updated the build instructions in the `README.md` file to use `mvn deploy` instead of `mvn pakage` for creating the JAR file.

PDF signing logic:

* Changed the `setProportionalIcon` property for image fields in `PreparePdfToSignLogic.java` to `false`, ensuring that images used as icons are not scaled proportionally.